### PR TITLE
Fix stats serialization and expose interval

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -1,9 +1,6 @@
 from utils import read_video, save_video
 from trackers import Tracker
-import argparse
-import cv2
 import numpy as np
-import os
 import uuid
 from team_assigner import TeamAssigner
 from player_ball_assigner import PlayerBallAssigner
@@ -12,22 +9,47 @@ from view_transformer import ViewTransformer
 from speed_and_distance_estimator import SpeedAndDistance_Estimator
 from stats_collector import collect_interval_stats, save_stats_to_json
 
+
 def process_video(video_path, features, stats_interval=30, stats_output="./output_videos/stats.json"):
+    """Run analysis on the provided video.
+
+    Parameters
+    ----------
+    video_path : str
+        Path to the input video.
+    features : tuple(bool)
+        Flags for (player_detection, ball_tracking, emotion_detection,
+        referee_signal, voice_whistle).
+    stats_interval : int, optional
+        Interval (in seconds) at which statistics are aggregated.
+    stats_output : str, optional
+        Where to save the statistics JSON.
+    """
+
+    player_detection, ball_tracking, emotion_detection, referee_signal, voice_whistle = features
+
     video_frames, fps = read_video(video_path)
-      # Generate unique name
     video_id = str(uuid.uuid4())
     output_path = f"/app/output_videos/{video_id}.avi"
 
-    # Initialize Tracker
+    if not player_detection:
+        save_video(video_frames, output_path, fps=fps)
+        save_stats_to_json([], stats_output)
+        if emotion_detection:
+            print("Emotion detection not implemented yet.")
+        if referee_signal:
+            print("Referee signal detection not implemented yet.")
+        if voice_whistle:
+            print("Voice whistle analysis not implemented yet.")
+        return output_path
+
     tracker = Tracker("./models/best.pt")
 
     tracks = tracker.get_object_tracks(
         video_frames, read_from_stub=True, stub_path="stubs/track_stubs.pkl"
     )
-    # Get object positions
     tracker.add_position_to_tracks(tracks)
 
-    # camera movement estimator
     camera_movement_estimator = CameraMovementEstimator(video_frames[0])
     camera_movement_per_frame = camera_movement_estimator.get_camera_movement(
         video_frames, read_from_stub=True, stub_path="stubs/camera_movement_stub.pkl"
@@ -36,18 +58,14 @@ def process_video(video_path, features, stats_interval=30, stats_output="./outpu
         tracks, camera_movement_per_frame
     )
 
-    # View Trasnformer
     view_transformer = ViewTransformer()
     view_transformer.add_transformed_position_to_tracks(tracks)
 
-    # Interpolate Ball Positions
     tracks["ball"] = tracker.interpolate_ball_positions(tracks["ball"])
 
-    # Speed and distance estimator
     speed_and_distance_estimator = SpeedAndDistance_Estimator(frame_rate=fps)
     speed_and_distance_estimator.add_speed_and_distance_to_tracks(tracks)
 
-    # Assign Player Teams
     team_assigner = TeamAssigner()
     team_assigner.assign_team_color(video_frames[0], tracks["players"][0])
 
@@ -61,43 +79,52 @@ def process_video(video_path, features, stats_interval=30, stats_output="./outpu
                 team_assigner.team_colors[team]
             )
 
-    # Assign Ball Aquisition
-    player_assigner = PlayerBallAssigner()
     team_ball_control = []
-    for frame_num, player_track in enumerate(tracks["players"]):
-        ball_bbox = tracks["ball"][frame_num][1]["bbox"]
-        assigned_player = player_assigner.assign_ball_to_player(player_track, ball_bbox)
-
-        if assigned_player != -1:
-            tracks["players"][frame_num][assigned_player]["has_ball"] = True
-            team_ball_control.append(
-                tracks["players"][frame_num][assigned_player]["team"]
+    if ball_tracking:
+        player_assigner = PlayerBallAssigner()
+        for frame_num, player_track in enumerate(tracks["players"]):
+            ball_bbox = tracks["ball"][frame_num][1]["bbox"]
+            assigned_player = player_assigner.assign_ball_to_player(
+                player_track, ball_bbox
             )
-        else:
-            team_ball_control.append(team_ball_control[-1])
+
+            if assigned_player != -1:
+                tracks["players"][frame_num][assigned_player]["has_ball"] = True
+                team_ball_control.append(
+                    tracks["players"][frame_num][assigned_player]["team"]
+                )
+            else:
+                team_ball_control.append(
+                    team_ball_control[-1] if team_ball_control else None
+                )
+    else:
+        team_ball_control = [None] * len(video_frames)
+
     team_ball_control = np.array(team_ball_control)
 
-    # Draw output
-    ## Draw object Tracks
     output_video_frames = tracker.draw_annotations(
         video_frames, tracks, team_ball_control
     )
 
-    ## Draw Camera movement
     output_video_frames = camera_movement_estimator.draw_camera_movement(
         output_video_frames, camera_movement_per_frame
     )
 
-    ## Draw Speed and Distance
-    speed_and_distance_estimator.draw_speed_and_distance(output_video_frames, tracks)
+    speed_and_distance_estimator.draw_speed_and_distance(
+        output_video_frames, tracks
+    )
 
+    save_video(output_video_frames, output_path, fps=fps)
 
-    # Save video
-    save_video(output_video_frames ,output_path, fps=fps)
-      # Save stats
     stats = collect_interval_stats(tracks, team_ball_control, fps, stats_interval)
     save_stats_to_json(stats, stats_output)
+
+    if emotion_detection:
+        print("Emotion detection not implemented yet.")
+    if referee_signal:
+        print("Referee signal detection not implemented yet.")
+    if voice_whistle:
+        print("Voice whistle analysis not implemented yet.")
+
     return output_path
 
-
-    

--- a/gradio_ui.py
+++ b/gradio_ui.py
@@ -1,28 +1,16 @@
 
 import gradio as gr
-import os
 from analyzer import process_video as run_analysis
-import shutil
-import argparse
 
-def analyze_video(video_path, *features):
+def analyze_video(video_path, stats_interval, *features):
     # Call the analysis pipeline from main.py
     try:
-        
-        parser = argparse.ArgumentParser()
-        parser.add_argument(
-            "--stats-interval",
-            type=int,
-            default=30,
-            help="Interval in seconds at which to record statistics",
+        output_path = run_analysis(
+            video_path,
+            features,
+            stats_interval=int(stats_interval),
+            stats_output="./output_videos/stats.json",
         )
-        parser.add_argument(
-            "--stats-output",
-            default="./output_videos/stats.json",
-            help="Path to the JSON file where stats will be saved",
-        )
-        args = parser.parse_args()
-        output_path = run_analysis(video_path, features, stats_interval=args.stats_interval, stats_output=args.stats_output)
         return "Analysis Complete", output_path
     except Exception as e:
         return f"Error: {e}", None
@@ -34,12 +22,13 @@ def create_commentary(video_path):
 with gr.Blocks() as interface:
     gr.Markdown("## Isaac Soccer Analyzer")
     video_input = gr.Video(label="Upload Match Video")
+    stats_interval = gr.Number(value=30, label="Stats Interval (sec)")
     features = [
         gr.Checkbox(label="Player Detection"),
         gr.Checkbox(label="Ball Tracking"),
         gr.Checkbox(label="Emotion Detection"),
         gr.Checkbox(label="Referee Signal Detection"),
-        gr.Checkbox(label="Voice Whistle Analysis")
+        gr.Checkbox(label="Voice Whistle Analysis"),
     ]
     analyze_btn = gr.Button("Analyze Video")
     analyze_output = gr.Textbox(label="Analysis Output")
@@ -50,8 +39,8 @@ with gr.Blocks() as interface:
 
     analyze_btn.click(
         analyze_video,
-        inputs=[video_input] + features,
-        outputs=[analyze_output, output_video]
+        inputs=[video_input, stats_interval] + features,
+        outputs=[analyze_output, output_video],
     )
 
     commentary_btn.click(

--- a/stats_collector.py
+++ b/stats_collector.py
@@ -44,12 +44,18 @@ def collect_interval_stats(tracks, team_ball_control, fps, interval_seconds):
                 if pdata["speeds"]
                 else None
             )
+            team_value = pdata["team"]
+            if team_value is not None:
+                try:
+                    team_value = int(team_value)
+                except Exception:
+                    pass
             interval_stat["players"].append(
                 {
-                    "id": pid,
-                    "team": pdata["team"],
-                    "distance": pdata["distance"],
-                    "avg_speed": avg_speed,
+                    "id": int(pid),
+                    "team": team_value,
+                    "distance": float(pdata["distance"]),
+                    "avg_speed": float(avg_speed) if avg_speed is not None else None,
                     "ball_possession_time": pdata["has_ball_frames"] / fps,
                 }
             )


### PR DESCRIPTION
## Summary
- convert numpy values to native Python types before JSON serialization
- allow stats interval to be specified in Gradio UI and pass to analyzer
- route feature checkboxes through analyzer with basic toggling

## Testing
- `python -m pytest`
- `python main.py --stats-interval 30 --stats-output ./output_videos/stats.json` *(failed: ImportError: libGL.so.1: cannot open shared object file)*
- `python - <<'PY'` *(manual serialization check)*

------
https://chatgpt.com/codex/tasks/task_e_6891b6f1985c8332b37d4f0162ff23e0