### PR TITLE
Run processing regardless of overlay toggles

### DIFF
--- a/trackers/tracker.py
+++ b/trackers/tracker.py
@@ -183,8 +183,9 @@ class Tracker:
 
         return frame
 
-    def draw_annotations(self,video_frames, tracks,team_ball_control):
-        output_video_frames= []
+    def draw_annotations(self, video_frames, tracks, team_ball_control,
+                         draw_players=True, draw_ball=True):
+        output_video_frames = []
         for frame_num, frame in enumerate(video_frames):
             frame = frame.copy()
 
@@ -193,21 +194,22 @@ class Tracker:
             referee_dict = tracks["referees"][frame_num]
 
             # Draw Players
-            for track_id, player in player_dict.items():
-                color = player.get("team_color",(0,0,255))
-                frame = self.draw_ellipse(frame, player["bbox"],color, track_id)
+            if draw_players:
+                for track_id, player in player_dict.items():
+                    color = player.get("team_color", (0, 0, 255))
+                    frame = self.draw_ellipse(frame, player["bbox"], color, track_id)
 
-                if player.get('has_ball',False):
-                    frame = self.draw_traingle(frame, player["bbox"],(0,0,255))
+                    if draw_ball and player.get("has_ball", False):
+                        frame = self.draw_traingle(frame, player["bbox"], (0, 0, 255))
 
-            # Draw Referee
-            for _, referee in referee_dict.items():
-                frame = self.draw_ellipse(frame, referee["bbox"],(0,255,255))
-            
-            # Draw ball 
-            for track_id, ball in ball_dict.items():
-                frame = self.draw_traingle(frame, ball["bbox"],(0,255,0))
+                # Draw Referee
+                for _, referee in referee_dict.items():
+                    frame = self.draw_ellipse(frame, referee["bbox"], (0, 255, 255))
 
+            # Draw ball
+            if draw_ball:
+                for track_id, ball in ball_dict.items():
+                    frame = self.draw_traingle(frame, ball["bbox"], (0, 255, 0))
 
             # Draw Team Ball Control
             frame = self.draw_team_ball_control(frame, frame_num, team_ball_control)


### PR DESCRIPTION
## Summary
- Always compute tracking and statistics regardless of player or ball overlay settings.
- Add overlay toggles to annotation drawing so player and ball visuals can be hidden while analytics still run.

## Testing
- `python -m py_compile analyzer.py trackers/tracker.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891d8033c908332a9bb2ca489a408f5